### PR TITLE
Validate Coordinates

### DIFF
--- a/Sources/SwiftLocation/LocationManager.swift
+++ b/Sources/SwiftLocation/LocationManager.swift
@@ -828,10 +828,12 @@ extension LocationManager: CLLocationManagerDelegate {
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let mostRecentLocation = locations.last else {
-            return
-        }
+        guard let mostRecentLocation = locations.last else { return }
+        guard mostRecentLocation.coordinate.latitude.inRange(-180, 180) else { return }
+        guard mostRecentLocation.coordinate.longitude.inRange(-180, 180) else { return }
+
         lastLocation = mostRecentLocation
+
         for request in queueLocationRequests { // dispatch location to any request
             request.complete(location: mostRecentLocation)
         }
@@ -888,4 +890,13 @@ extension LocationManager: CLLocationManagerDelegate {
         }
     }
     
+}
+
+// MARK: - Private
+
+private extension Double {
+
+    func inRange(_ lower: Double, _ upper: Double) -> Bool {
+        return (self > lower && self < upper)
+    }
 }

--- a/Sources/SwiftLocation/Requests/LocationRequest.swift
+++ b/Sources/SwiftLocation/Requests/LocationRequest.swift
@@ -186,7 +186,10 @@ public class LocationRequest: ServiceRequest, Hashable {
             // overridden by custom validator rule
             return customValidationRule(location,location.timestamp.timeIntervalSinceNow)
         }
-        
+
+        guard location.coordinate.latitude.inRange(-180, 180) else { return false }
+        guard location.coordinate.longitude.inRange(-180, 180) else { return false }
+
         guard location.horizontalAccuracy < accuracy.value, location.horizontalAccuracy >= 0 else {
             return false // accuracy is not enough
         }
@@ -277,4 +280,13 @@ public extension LocationRequest {
         case fixed(minInterval: TimeInterval?, minDistance: CLLocationDistance?)
     }
     
+}
+
+// MARK: - Private
+
+private extension Double {
+
+    func inRange(_ lower: Double, _ upper: Double) -> Bool {
+        return (self > lower && self < upper)
+    }
 }

--- a/Sources/SwiftLocation/Requests/LocationRequest.swift
+++ b/Sources/SwiftLocation/Requests/LocationRequest.swift
@@ -187,9 +187,6 @@ public class LocationRequest: ServiceRequest, Hashable {
             return customValidationRule(location,location.timestamp.timeIntervalSinceNow)
         }
 
-        guard location.coordinate.latitude.inRange(-180, 180) else { return false }
-        guard location.coordinate.longitude.inRange(-180, 180) else { return false }
-
         guard location.horizontalAccuracy < accuracy.value, location.horizontalAccuracy >= 0 else {
             return false // accuracy is not enough
         }
@@ -280,13 +277,4 @@ public extension LocationRequest {
         case fixed(minInterval: TimeInterval?, minDistance: CLLocationDistance?)
     }
     
-}
-
-// MARK: - Private
-
-private extension Double {
-
-    func inRange(_ lower: Double, _ upper: Double) -> Bool {
-        return (self > lower && self < upper)
-    }
 }


### PR DESCRIPTION
### Description

In some cases when user location is probably not known `LocationManager.shared.lastLocation` returns location with latitude and longitude -180 -180. Previously this crashed Mapbox SDK before we implemented a workaround (see related tickets)

#### Tasks

- [x] Validate range of coordinates 